### PR TITLE
Remove en.yml from solidus_hooks

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,0 @@
----
-en:
-  activerecord:
-  spree:


### PR DESCRIPTION
The empty sections in this en.yml were corrupting the load of the translations from other gems.